### PR TITLE
mod-braille: updated dependencies

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -68,7 +68,7 @@
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
                 <artifactId>dtbook-to-pef</artifactId>
-                <version>1.1.0</version>
+                <version>1.1.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
@@ -115,7 +115,7 @@
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
                 <artifactId>liblouis-formatter</artifactId>
-                <version>1.2.0</version>
+                <version>1.2.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
@@ -173,7 +173,7 @@
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
                 <artifactId>pef-utils</artifactId>
-                <version>1.1.1</version>
+                <version>1.1.2-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
@@ -198,7 +198,7 @@
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
                 <artifactId>zedai-to-pef</artifactId>
-                <version>1.1.0</version>
+                <version>1.1.1-SNAPSHOT</version>
             </dependency>
             <!--
           Braille-specific dependencies

--- a/pipeline-braille-scripts/dtbook-to-pef/src/main/resources/META-INF/catalog.xml
+++ b/pipeline-braille-scripts/dtbook-to-pef/src/main/resources/META-INF/catalog.xml
@@ -4,6 +4,8 @@
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" xmlns:px="http://www.daisy.org/ns/pipeline">
   <uri name="http://www.daisy.org/pipeline/modules/braille/dtbook-to-pef/dtbook-to-pef.xpl" uri="../xml/dtbook-to-pef.xpl" px:script="true"/>
   <uri name="http://www.daisy.org/pipeline/modules/braille/dtbook-to-pef/library.xpl" uri="../xml/library.xpl"/>
+  <nextCatalog catalog="org:daisy:pipeline:modules:file-utils"/>
+  <nextCatalog catalog="org:daisy:pipeline:modules:fileset-utils"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:dtbook-utils"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:dtbook-to-zedai"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:braille:zedai-to-pef"/>

--- a/pipeline-braille-scripts/zedai-to-pef/src/main/resources/META-INF/catalog.xml
+++ b/pipeline-braille-scripts/zedai-to-pef/src/main/resources/META-INF/catalog.xml
@@ -11,4 +11,5 @@
   <nextCatalog catalog="org:daisy:pipeline:modules:braille:xml-to-pef"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:braille:pef-utils"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:metadata-utils"/>
+  <nextCatalog catalog="org:daisy:pipeline:modules:file-utils"/>
 </catalog>

--- a/pipeline-braille-utils/liblouis/liblouis-formatter/src/main/resources/xml/utils/fileset-add-tempfile.xpl
+++ b/pipeline-braille-utils/liblouis/liblouis-formatter/src/main/resources/xml/utils/fileset-add-tempfile.xpl
@@ -16,7 +16,6 @@
     
     <p:import href="http://www.daisy.org/pipeline/modules/fileset-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/file-utils/library.xpl"/>
-    <p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl"/>
     
     <px:tempfile delete-on-exit="false" name="tempfile">
         <p:with-option name="href" select="/d:fileset/@xml:base">

--- a/pipeline-braille-utils/pef-utils/src/main/resources/META-INF/catalog.xml
+++ b/pipeline-braille-utils/pef-utils/src/main/resources/META-INF/catalog.xml
@@ -7,4 +7,5 @@
   <nextCatalog catalog="org:daisy:pipeline:modules:braille:pef-calabash"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:braille:pef-saxon"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:braille:pef-to-html"/>
+  <nextCatalog catalog="org:daisy:pipeline:modules:file-utils"/>
 </catalog>


### PR DESCRIPTION
I did a quick scan through and removed unused module dependencies and added missing module dependencies from the XML catalogs.

see also (can be merged separately):
daisy/pipeline-modules-common#80
daisy/pipeline-scripts-utils#75
daisy/pipeline-scripts#83
daisy/pipeline-mod-braille#14
daisy/pipeline-mod-tts#52