### PR TITLE
Implement text-transform property

### DIFF
--- a/pipeline-braille-utils/css-utils/src/main/resources/xml/transform/block-translator-template.xsl
+++ b/pipeline-braille-utils/css-utils/src/main/resources/xml/transform/block-translator-template.xsl
@@ -77,8 +77,8 @@
 											<xsl:attribute name="xml:space" select="$space"/>
 										</xsl:if>
 										<xsl:sequence select="css:style-attribute(css:serialize-declaration-list(
-										                        css:specified-properties($inline-properties, true(), false(), false(), $this)
-										                        [not(@value='initial')]))"/>
+										                        css:computed-properties($inline-properties, false(), $this)
+										                        [not(@value=css:initial-value(@name))]))"/>
 										<xsl:for-each select="current-group()">
 											<xsl:sequence select="."/>
 										</xsl:for-each>

--- a/pipeline-braille-utils/css/css-calabash/src/main/java/org/daisy/braille/css/calabash/CSSInlineStep.java
+++ b/pipeline-braille-utils/css/css-calabash/src/main/java/org/daisy/braille/css/calabash/CSSInlineStep.java
@@ -112,10 +112,12 @@ public class CSSInlineStep extends DefaultStep {
 			XdmNode source = sourcePipe.read();
 			Document doc = (Document)DocumentOverNodeInfo.wrap(source.getUnderlyingNode());
 			URL defaultSheet = asURL(emptyToNull(getOption(_default_stylesheet, "")));
-			resultPipe.write((new InlineCSSWriter(doc, runtime, defaultSheet)).getResult()); }
+			resultPipe.write((new InlineCSSWriter(doc, runtime, defaultSheet)).getResult());
+		}
 		catch (Exception e) {
 			logger.error("css:inline failed", e);
-			throw new XProcException(step.getNode(), e); }
+			throw new XProcException(step.getNode(), e);
+		}
 	}
 	
 	@Component(
@@ -202,7 +204,8 @@ public class CSSInlineStep extends DefaultStep {
 						addAttribute(new QName(attr.getPrefix(), attr.getNamespaceURI(), attr.getLocalName()), attr.getNodeValue());
 					else if ("style".equals(attr.getLocalName())) {}
 					else
-						addAttribute(new QName(attr.getNamespaceURI(), attr.getLocalName()), attr.getNodeValue()); }
+						addAttribute(new QName(attr.getNamespaceURI(), attr.getLocalName()), attr.getNodeValue());
+				}
 				StringBuilder style = new StringBuilder();
 				NodeData brailleData = brailleStylemap.get((Element)node);
 				if (brailleData != null)
@@ -226,17 +229,20 @@ public class CSSInlineStep extends DefaultStep {
 					else
 						page = pages.get(pageProperty.toString());
 					if (page != null)
-						insertPageStyle(style, page, pages.get("auto")); }
+						insertPageStyle(style, page, pages.get("auto"));
+				}
 				else if (isRoot) {
 					RulePage page = pages.get("auto");
 					if (page != null)
-						insertPageStyle(style, page, null); }
-				if (normalizeSpace(style).length() > 0) {
-					addAttribute(_style, style.toString().trim()); }
+						insertPageStyle(style, page, null);
+				}
+				if (normalizeSpace(style).length() > 0)
+					addAttribute(_style, style.toString().trim());
 				receiver.startContent();
 				for (Node child = node.getFirstChild(); child != null; child = child.getNextSibling())
 					traverse(child);
-				addEndElement(); }
+				addEndElement();
+			}
 			else if (node.getNodeType() == Node.COMMENT_NODE)
 				addComment(node.getNodeValue());
 			else if (node.getNodeType() == Node.TEXT_NODE)
@@ -256,7 +262,8 @@ public class CSSInlineStep extends DefaultStep {
 				List<NamespaceBinding> namespaces = new ArrayList<NamespaceBinding>();
 				Iterators.<NamespaceBinding>addAll(namespaces, NamespaceIterator.iterateNamespaces(inode));
 				inscopeNS = Iterables.<NamespaceBinding>toArray(namespaces, NamespaceBinding.class);
-				seenRoot = true; }
+				seenRoot = true;
+			}
 			receiver.setSystemId(element.getBaseURI());
 			addStartElement(new NameOfNode(inode), inode.getSchemaType(), inscopeNS);
 		}
@@ -282,14 +289,17 @@ public class CSSInlineStep extends DefaultStep {
 				builder.append(termToString.apply(value));
 			else {
 				CSSProperty prop = nodeData.getProperty(key);
-				builder.append(prop); }
-			builder.append("; "); }
+				builder.append(prop);
+			}
+			builder.append("; ");
+		}
 	}
 	
 	private static void insertPseudoStyle(StringBuilder builder, NodeData nodeData, Selector.PseudoDeclaration decl) {
 		if (builder.length() > 0 && !builder.toString().endsWith("} ")) {
 			builder.insert(0, "{ ");
-			builder.append("} "); }
+			builder.append("} ");
+		}
 		builder.append(decl.isPseudoElement() ? "::" : ":").append(decl.value()).append(" { ");
 		insertStyle(builder, nodeData);
 		builder.append("} ");
@@ -298,7 +308,8 @@ public class CSSInlineStep extends DefaultStep {
 	private static void insertPageStyle(StringBuilder builder, RulePage rulePage, RulePage inheritFrom) {
 		if (builder.length() > 0 && !builder.toString().endsWith("} ")) {
 			builder.insert(0, "{ ");
-			builder.append("} "); }
+			builder.append("} ");
+		}
 		builder.append("@page ");
 		String pseudo = rulePage.getPseudo();
 		if (pseudo != null && !"".equals(pseudo))
@@ -307,7 +318,8 @@ public class CSSInlineStep extends DefaultStep {
 		List<String> seen = new ArrayList<String>();
 		for (Declaration decl : Iterables.<Declaration>filter(rulePage, Declaration.class)) {
 			seen.add(decl.getProperty());
-			insertDeclaration(builder, decl); }
+			insertDeclaration(builder, decl);
+		}
 		if (inheritFrom != null)
 			for (Declaration decl : Iterables.<Declaration>filter(inheritFrom, Declaration.class))
 				if (!seen.contains(decl.getProperty()))
@@ -315,7 +327,8 @@ public class CSSInlineStep extends DefaultStep {
 		seen.clear();
 		for (RuleMargin margin : Iterables.<RuleMargin>filter(rulePage, RuleMargin.class)) {
 			seen.add(margin.getMarginArea().value);
-			insertMarginStyle(builder, margin); }
+			insertMarginStyle(builder, margin);
+		}
 		if (inheritFrom != null)
 			for (RuleMargin margin : Iterables.<RuleMargin>filter(inheritFrom, RuleMargin.class))
 				if (!seen.contains(margin.getMarginArea().value))

--- a/pipeline-braille-utils/css/css-core/src/main/java/org/daisy/braille/css/BrailleCSSDeclarationTransformer.java
+++ b/pipeline-braille-utils/css/css-core/src/main/java/org/daisy/braille/css/BrailleCSSDeclarationTransformer.java
@@ -17,6 +17,7 @@ import org.daisy.braille.css.BrailleCSSProperty.Padding;
 import org.daisy.braille.css.BrailleCSSProperty.Page;
 import org.daisy.braille.css.BrailleCSSProperty.StringSet;
 import org.daisy.braille.css.BrailleCSSProperty.TextIndent;
+import org.daisy.braille.css.BrailleCSSProperty.TextTransform;
 
 import cz.vutbr.web.css.CSSFactory;
 import cz.vutbr.web.css.CSSProperty;
@@ -279,6 +280,31 @@ public class BrailleCSSDeclarationTransformer extends DeclarationTransformer {
 			Map<String, CSSProperty> properties, Map<String, Term<?>> values) {
 		return genericOneIdentOrInteger(TextIndent.class, TextIndent.integer, false,
 				d, properties, values);
+	}
+	
+	@SuppressWarnings("unused")
+	private boolean processTextTransform(Declaration d,
+			Map<String, CSSProperty> properties, Map<String, Term<?>> values) {
+		
+		if (d.size() == 1 && genericOneIdent(TextTransform.class, d, properties))
+			return true;
+		
+		TermList list = tf.createList();
+		for (Term<?> t : d.asList()) {
+			if (t instanceof TermIdent) {
+				String value = ((TermIdent)t).getValue().toLowerCase();
+				if (!value.equals("auto"))
+					list.add(t); }
+			else
+				return false;
+		}
+		
+		if (list.isEmpty())
+			return false;
+		
+		properties.put("text-transform", TextTransform.list_values);
+		values.put("text-transform", list);
+		return true;
 	}
 	
 	/****************************************************************

--- a/pipeline-braille-utils/css/css-core/src/main/java/org/daisy/braille/css/BrailleCSSDeclarationTransformer.java
+++ b/pipeline-braille-utils/css/css-core/src/main/java/org/daisy/braille/css/BrailleCSSDeclarationTransformer.java
@@ -285,7 +285,27 @@ public class BrailleCSSDeclarationTransformer extends DeclarationTransformer {
 	@SuppressWarnings("unused")
 	private boolean processTextTransform(Declaration d,
 			Map<String, CSSProperty> properties, Map<String, Term<?>> values) {
-		return genericOneIdent(TextTransform.class, d, properties);
+		if (d.size() == 1 && genericOneIdent(TextTransform.class, d, properties))
+			return true;
+
+		TermList list = tf.createList();
+		for (Term<?> t : d.asList()) {
+			if (t instanceof TermIdent) {
+				String value = ((TermIdent)t).getValue().toLowerCase();
+				if (!value.equals("none") && !value.equals("auto")
+						&& !value.equals("uppercase") && !value.equals("lowercase"))
+					list.add(t);
+			}
+			else
+				return false;
+		}
+
+		if (list.isEmpty())
+			return false;
+
+		properties.put("text-transform", TextTransform.list_values);
+		values.put("text-transform", list);
+		return true;
 	}
 	
 	/****************************************************************

--- a/pipeline-braille-utils/css/css-core/src/main/java/org/daisy/braille/css/BrailleCSSDeclarationTransformer.java
+++ b/pipeline-braille-utils/css/css-core/src/main/java/org/daisy/braille/css/BrailleCSSDeclarationTransformer.java
@@ -285,26 +285,7 @@ public class BrailleCSSDeclarationTransformer extends DeclarationTransformer {
 	@SuppressWarnings("unused")
 	private boolean processTextTransform(Declaration d,
 			Map<String, CSSProperty> properties, Map<String, Term<?>> values) {
-		
-		if (d.size() == 1 && genericOneIdent(TextTransform.class, d, properties))
-			return true;
-		
-		TermList list = tf.createList();
-		for (Term<?> t : d.asList()) {
-			if (t instanceof TermIdent) {
-				String value = ((TermIdent)t).getValue().toLowerCase();
-				if (!value.equals("auto"))
-					list.add(t); }
-			else
-				return false;
-		}
-		
-		if (list.isEmpty())
-			return false;
-		
-		properties.put("text-transform", TextTransform.list_values);
-		values.put("text-transform", list);
-		return true;
+		return genericOneIdent(TextTransform.class, d, properties);
 	}
 	
 	/****************************************************************

--- a/pipeline-braille-utils/css/css-core/src/main/java/org/daisy/braille/css/BrailleCSSProperty.java
+++ b/pipeline-braille-utils/css/css-core/src/main/java/org/daisy/braille/css/BrailleCSSProperty.java
@@ -239,4 +239,27 @@ public interface BrailleCSSProperty extends CSSProperty {
 			return text;
 		}
 	}
+	
+	public enum TextTransform implements BrailleCSSProperty {
+		list_values(""), AUTO("auto"), INHERIT("inherit");
+		
+		private String text;
+		
+		private TextTransform(String text) {
+			this.text = text;
+		}
+		
+		public boolean inherited() {
+			return false;
+		}
+		
+		public boolean equalsInherit() {
+			return this == INHERIT;
+		}
+		
+		@Override
+		public String toString() {
+			return text;
+		}
+	}
 }

--- a/pipeline-braille-utils/css/css-core/src/main/java/org/daisy/braille/css/BrailleCSSProperty.java
+++ b/pipeline-braille-utils/css/css-core/src/main/java/org/daisy/braille/css/BrailleCSSProperty.java
@@ -241,7 +241,7 @@ public interface BrailleCSSProperty extends CSSProperty {
 	}
 	
 	public enum TextTransform implements BrailleCSSProperty {
-		NONE("none"), AUTO("auto"), UPPERCASE("uppercase"), LOWERCASE("lowercase"), INHERIT("inherit");
+		list_values(""), NONE("none"), AUTO("auto"), UPPERCASE("uppercase"), LOWERCASE("lowercase"), INHERIT("inherit");
 		
 		private String text;
 		

--- a/pipeline-braille-utils/css/css-core/src/main/java/org/daisy/braille/css/BrailleCSSProperty.java
+++ b/pipeline-braille-utils/css/css-core/src/main/java/org/daisy/braille/css/BrailleCSSProperty.java
@@ -241,7 +241,7 @@ public interface BrailleCSSProperty extends CSSProperty {
 	}
 	
 	public enum TextTransform implements BrailleCSSProperty {
-		list_values(""), AUTO("auto"), INHERIT("inherit");
+		NONE("none"), AUTO("auto"), UPPERCASE("uppercase"), LOWERCASE("lowercase"), INHERIT("inherit");
 		
 		private String text;
 		

--- a/pipeline-braille-utils/css/css-core/src/main/java/org/daisy/braille/css/SupportedBrailleCSS.java
+++ b/pipeline-braille-utils/css/css-core/src/main/java/org/daisy/braille/css/SupportedBrailleCSS.java
@@ -32,6 +32,7 @@ import org.daisy.braille.css.BrailleCSSProperty.Padding;
 import org.daisy.braille.css.BrailleCSSProperty.Page;
 import org.daisy.braille.css.BrailleCSSProperty.StringSet;
 import org.daisy.braille.css.BrailleCSSProperty.TextIndent;
+import org.daisy.braille.css.BrailleCSSProperty.TextTransform;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +44,7 @@ public class SupportedBrailleCSS implements SupportedCSS {
 	
 	private static Logger log = LoggerFactory.getLogger(SupportedBrailleCSS.class);
 	
-	private static final int TOTAL_SUPPORTED_DECLARATIONS = 35;
+	private static final int TOTAL_SUPPORTED_DECLARATIONS = 36;
 	
 	private static final TermFactory tf = CSSFactory.getTermFactory();
 	
@@ -231,6 +232,8 @@ public class SupportedBrailleCSS implements SupportedCSS {
 		embossedProperties.add("string-set");
 		props.put("content", Content.NONE);
 		embossedProperties.add("content");
+		props.put("text-transform", TextTransform.AUTO);
+		embossedProperties.add("text-transform");
 		
 		/* ----------- */
 		/* media print */

--- a/pipeline-braille-utils/css/css-core/src/main/resources/xml/base.xsl
+++ b/pipeline-braille-utils/css/css-core/src/main/resources/xml/base.xsl
@@ -409,6 +409,12 @@
         </xsl:choose>
     </xsl:template>
     
+    <xsl:template match="css:property" mode="css:compute">
+        <xsl:param name="validate" as="xs:boolean"/>
+        <xsl:param name="context" as="element()"/>
+        <xsl:sequence select="."/>
+    </xsl:template>
+    
     <xsl:function name="css:specified-properties" as="element()*">
         <xsl:param name="properties"/>
         <xsl:param name="concretize-inherit" as="xs:boolean"/>
@@ -453,6 +459,17 @@
         </xsl:variable>
         <xsl:apply-templates select="$declarations" mode="css:default">
             <xsl:with-param name="concretize-initial" select="$concretize-initial"/>
+        </xsl:apply-templates>
+    </xsl:function>
+    
+    <xsl:function name="css:computed-properties" as="element()*">
+        <xsl:param name="properties"/>
+        <xsl:param name="validate" as="xs:boolean"/>
+        <xsl:param name="context" as="element()"/>
+        <xsl:apply-templates select="css:specified-properties($properties, true(), true(), $validate, $context)"
+                             mode="css:compute">
+            <xsl:with-param name="validate" select="$validate"/>
+            <xsl:with-param name="context" select="$context"/>
         </xsl:apply-templates>
     </xsl:function>
     

--- a/pipeline-braille-utils/css/css-core/src/main/resources/xml/braille-css.xsl
+++ b/pipeline-braille-utils/css/css-core/src/main/resources/xml/braille-css.xsl
@@ -260,6 +260,31 @@
         <xsl:sequence select="if ($index) then matches($display, $css:applies-to[$index]) else false()"/>
     </xsl:function>
     
+    <!-- ================== -->
+    <!-- Special inheriting -->
+    <!-- ================== -->
+    
+    <xsl:template match="css:property[@name='text-transform']" mode="css:compute">
+        <xsl:param name="validate" as="xs:boolean"/>
+        <xsl:param name="context" as="element()"/>
+        <xsl:variable name="parent" as="element()?" select="$context/ancestor::*[not(self::css:* except self::css:box)][1]"/>
+        <xsl:choose>
+            <xsl:when test="not(exists($parent))">
+                <xsl:sequence select="."/>
+            </xsl:when>
+            <xsl:when test="@value=('auto','initial')">
+                <xsl:sequence select="css:computed-properties(@name, $validate, $parent)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:variable name="parent-computed" as="element()"
+                              select="css:computed-properties(@name, $validate, $parent)"/>
+                <xsl:sequence select="if ($parent-computed/@value='auto')
+                                      then .
+                                      else css:property(@name, string-join((@value, $parent-computed/@value), ' '))"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
     <!-- ============== -->
     <!-- Counter Styles -->
     <!-- ============== -->

--- a/pipeline-braille-utils/css/css-core/src/main/resources/xml/braille-css.xsl
+++ b/pipeline-braille-utils/css/css-core/src/main/resources/xml/braille-css.xsl
@@ -90,7 +90,7 @@
                  re:exact(re:or(('normal','pre-wrap','pre-line'))),
                  re:exact(re:or(('auto','manual','none'))),
                  re:exact(concat('(',$css:NON_NEGATIVE_INTEGER_RE,')\s+(',$css:NON_NEGATIVE_INTEGER_RE,')')),
-                 re:exact(re:or(('none','auto','uppercase','lowercase'))),
+                 re:exact(re:or(($css:IDENT_LIST_RE,'none','auto','uppercase','lowercase'))),
                  re:exact(re:or(('normal','italic','oblique'))),
                  re:exact(re:or(('normal','bold','100','200','300','400','500','600','700','800','900'))),
                  re:exact(re:or(('none','underline','overline','line-through','blink'))),

--- a/pipeline-braille-utils/css/css-core/src/main/resources/xml/braille-css.xsl
+++ b/pipeline-braille-utils/css/css-core/src/main/resources/xml/braille-css.xsl
@@ -51,6 +51,7 @@
                  'white-space',
                  'hyphens',
                  'size',
+                 'text-transform',
                  'font-style',
                  'font-weight',
                  'text-decoration',
@@ -89,6 +90,7 @@
                  re:exact(re:or(('normal','pre-wrap','pre-line'))),
                  re:exact(re:or(('auto','manual','none'))),
                  re:exact(concat('(',$css:NON_NEGATIVE_INTEGER_RE,')\s+(',$css:NON_NEGATIVE_INTEGER_RE,')')),
+                 re:exact(re:or(($css:IDENT_LIST_RE,'auto'))),
                  re:exact(re:or(('normal','italic','oblique'))),
                  re:exact(re:or(('normal','bold','100','200','300','400','500','600','700','800','900'))),
                  re:exact(re:or(('none','underline','overline','line-through','blink'))),
@@ -130,6 +132,7 @@
                  '.*',
                  '.*',
                  '.*',
+                 '.*',
                  '.*')"/>
     
     <xsl:variable name="css:initial-values" as="xs:string*"
@@ -165,6 +168,7 @@
                  'normal',
                  'manual',
                  '40 25',
+                 'auto',
                  'normal',
                  'normal',
                  'none',
@@ -172,6 +176,7 @@
     
     <xsl:variable name="css:media" as="xs:string*"
         select="('embossed',
+                 'embossed',
                  'embossed',
                  'embossed',
                  'embossed',

--- a/pipeline-braille-utils/css/css-core/src/main/resources/xml/braille-css.xsl
+++ b/pipeline-braille-utils/css/css-core/src/main/resources/xml/braille-css.xsl
@@ -90,7 +90,7 @@
                  re:exact(re:or(('normal','pre-wrap','pre-line'))),
                  re:exact(re:or(('auto','manual','none'))),
                  re:exact(concat('(',$css:NON_NEGATIVE_INTEGER_RE,')\s+(',$css:NON_NEGATIVE_INTEGER_RE,')')),
-                 re:exact(re:or(($css:IDENT_LIST_RE,'auto'))),
+                 re:exact(re:or(('none','auto','uppercase','lowercase'))),
                  re:exact(re:or(('normal','italic','oblique'))),
                  re:exact(re:or(('normal','bold','100','200','300','400','500','600','700','800','900'))),
                  re:exact(re:or(('none','underline','overline','line-through','blink'))),

--- a/pipeline-braille-utils/css/css-core/src/test/xspec/test_braille-css.xspec
+++ b/pipeline-braille-utils/css/css-core/src/test/xspec/test_braille-css.xspec
@@ -322,4 +322,21 @@
 		</x:expect>
 	</x:scenario>
 	
+	<x:scenario label="test_28">
+		<x:call function="css:computed-properties">
+			<x:param select="'text-transform'"/>
+			<x:param select="true()"/>
+			<x:param select="//foo">
+				<_ css:text-transform="bold">
+					<_>
+						<foo css:text-transform="italic"/>
+					</_>
+				</_>
+			</x:param>
+		</x:call>
+		<x:expect label="result">
+			<css:property name="text-transform" value="italic bold"/>
+		</x:expect>
+	</x:scenario>
+	
 </x:description>

--- a/pipeline-braille-utils/liblouis-utils/src/main/resources/xml/transform/liblouis-block-translate.xsl
+++ b/pipeline-braille-utils/liblouis-utils/src/main/resources/xml/transform/liblouis-block-translate.xsl
@@ -15,8 +15,8 @@
 		<xsl:variable name="style" as="xs:string*">
 			<xsl:for-each select="$text">
 				<xsl:variable name="inline-style" as="element()*"
-				              select="css:specified-properties($inline-properties, true(), false(), true(), parent::*)"/>
-				<xsl:sequence select="css:serialize-declaration-list($inline-style[not(@value='initial')])"/>
+				              select="css:computed-properties($inline-properties, true(), parent::*)"/>
+				<xsl:sequence select="css:serialize-declaration-list($inline-style[not(@value=css:initial-value(@name))])"/>
 			</xsl:for-each>
 		</xsl:variable>
 		<xsl:apply-templates select="node()[1]" mode="treewalk">

--- a/pipeline-braille-utils/liblouis-utils/src/test/xspec/test_liblouis-block-translate.xspec
+++ b/pipeline-braille-utils/liblouis-utils/src/test/xspec/test_liblouis-block-translate.xspec
@@ -23,4 +23,25 @@
     </x:expect>
   </x:scenario>
   
+  <x:scenario label="test_02" pending="liblouis typeform broken">
+    <x:context>
+      <doc xml:lang="en">
+        <p style="display: block">
+          <span style="text-transform: louis-ital">
+            foo <span style="text-transform: louis-bold">bar</span>
+          </span>
+        </p>
+      </doc>
+    </x:context>
+    <x:expect label="result">
+      <doc xml:lang="en">
+        <p style="{{ display: block }}">
+          <span>
+            ⠋⠕⠕ <span>⠃⠜</span>
+          </span>
+        </p>
+      </doc>
+    </x:expect>
+  </x:scenario>
+  
 </x:description>

--- a/pipeline-braille-utils/liblouis/liblouis-core/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisJnaImpl.java
+++ b/pipeline-braille-utils/liblouis/liblouis-core/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisJnaImpl.java
@@ -323,8 +323,10 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 				Map<String,String> style = new HashMap<String,String>(CSS_PARSER.split(cssStyle[i]));
 				String val = style.remove("text-transform");
 				typeform[i] = Typeform.PLAIN;
-				if (val != null)
+				if (val != null) {
+					text[i] = textFromTextTransform(text[i], val);
 					typeform[i] |= typeformFromTextTransform(val);
+				}
 				val = style.remove("hyphens");
 				hyphenate[i] = false;
 				if (val != null)
@@ -561,7 +563,7 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 	
 	private final static Splitter.MapSplitter CSS_PARSER
 		= Splitter.on(';').omitEmptyStrings().withKeyValueSeparator(Splitter.on(':').limit(2).trimResults());
-	
+
 	/**
 	 * @parameter style An inline CSS style
 	 * @returns the corresponding typeform. Possible values are:
@@ -593,6 +595,23 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 	}
 	
 	private final static Splitter TEXT_TRANSFORM_PARSER = Splitter.on(' ').omitEmptyStrings().trimResults();
+
+	/**
+	 * @parameter text The text to be transformed.
+	 * @parameter textTransform A text-transform value as a space separated list of keywords.
+	 * @returns the transformed text, or the original text if no transformations were performed.
+	 */
+	protected static String textFromTextTransform(String text, String textTransform) {
+		for (String tt : TEXT_TRANSFORM_PARSER.split(textTransform)) {
+			if (tt.equals("uppercase"))
+				text = text.toUpperCase();
+			else if (tt.equals("lowercase"))
+				text = text.toLowerCase();
+			else
+				logger.warn("text-transform: {} not supported", tt);
+		}
+		return text;
+	}
 	
 	/**
 	 * @parameter textTransform A text-transform value as a space separated list of keywords.

--- a/pipeline-braille-utils/liblouis/liblouis-core/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisJnaImpl.java
+++ b/pipeline-braille-utils/liblouis/liblouis-core/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisJnaImpl.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -297,12 +298,12 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 			byte[] typeform = new byte[cssStyle.length];
 			boolean[] hyphenate = new boolean[cssStyle.length];
 			for (int i = 0; i < cssStyle.length; i++) {
-				Map<String,String> style = CSS_PARSER.split(cssStyle[i]);
+				Map<String,String> style = new HashMap<String,String>(CSS_PARSER.split(cssStyle[i]));
 				String val = style.remove("text-transform");
 				typeform[i] = Typeform.PLAIN;
 				if (val != null)
 					typeform[i] |= typeformFromTextTransform(val);
-				style.remove("hyphens");
+				val = style.remove("hyphens");
 				hyphenate[i] = false;
 				if (val != null)
 					if ("auto".equals(val))

--- a/pipeline-braille-utils/liblouis/liblouis-core/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisJnaImpl.java
+++ b/pipeline-braille-utils/liblouis/liblouis-core/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisJnaImpl.java
@@ -298,12 +298,16 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 			boolean[] hyphenate = new boolean[cssStyle.length];
 			for (int i = 0; i < cssStyle.length; i++) {
 				Map<String,String> style = CSS_PARSER.split(cssStyle[i]);
-				typeform[i] = typeformFromInlineCSS(style);
-				if (style.containsKey("text-transform"))
-					typeform[i] |= typeformFromTextTransform(style.get("text-transform"));
+				String val = style.remove("text-transform");
+				typeform[i] = Typeform.PLAIN;
+				if (val != null)
+					typeform[i] |= typeformFromTextTransform(val);
+				style.remove("hyphens");
 				hyphenate[i] = false;
-				if (style.containsKey("hyphens") && "auto".equals(style.get("hyphens")))
-					hyphenate[i] = true; }
+				if (val != null)
+					if ("auto".equals(val))
+						hyphenate[i] = true;
+				typeform[i] |= typeformFromInlineCSS(style);}
 			return transform(text, typeform, hyphenate);
 		}
 		

--- a/pipeline-braille-utils/liblouis/liblouis-core/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisJnaImpl.java
+++ b/pipeline-braille-utils/liblouis/liblouis-core/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisJnaImpl.java
@@ -370,10 +370,10 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 					int i = 0;
 					while (unhyphenated[i].length() == 0) i++;
 					for (int j = 0; j < _typeform.length; j++) {
+						_typeform[j] = typeform[i];
 						if (positions != null && j < positions.length && (positions[j] & 4) == 4) {
 							i++;
-							while (unhyphenated[i].length() == 0) i++; }
-						_typeform[j] = typeform[i]; }
+							while (unhyphenated[i].length() == 0) i++; }}
 					break; }
 			try {
 				

--- a/pipeline-braille-utils/liblouis/liblouis-core/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisJnaImpl.java
+++ b/pipeline-braille-utils/liblouis/liblouis-core/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisJnaImpl.java
@@ -92,11 +92,15 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 						logger.debug("Resolved to " + join(resolved, ","));
 					else
 						logger.error("Table could not be resolved");
-						return resolved; }};
-			Louis.getLibrary().lou_registerTableResolver(_tableResolver); }
+					return resolved;
+				}
+			};
+			Louis.getLibrary().lou_registerTableResolver(_tableResolver);
+		}
 		catch (Throwable e) {
 			logger.error("liblouis service could not be loaded", e);
-			throw e; }
+			throw e;
+		}
 	}
 	
 	@Deactivate
@@ -117,7 +121,9 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 			if (libraryPath != null) {
 				Louis.setLibraryPath(asFile(libraryPath));
 				nativePath = path;
-				logger.debug("Registering liblouis library: " + libraryPath); }}
+				logger.debug("Registering liblouis library: " + libraryPath);
+			}
+		}
 	}
 	
 	protected void unbindLibrary(BundledNativePath path) {
@@ -195,10 +201,14 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 							try {
 								translators = Optional.<LiblouisTranslator>fromNullable(
 									new LiblouisTranslatorHyphenatorImpl(table)
-								).asSet(); }
+								).asSet();
+							}
 							catch (CompilationException e) {
-								logger.warn("Could not create translator for table: " + Arrays.toString(table), e); }
-							break; }}
+								logger.warn("Could not create translator for table: " + Arrays.toString(table), e);
+							}
+							break;
+					}
+				}
 				String hyphenatorQuery = "(locale:" + locale + ")";
 				if (!"auto".equals(hyphenator))
 					hyphenatorQuery = hyphenatorQuery + "(hyphenator:" + hyphenator + ")";
@@ -209,18 +219,26 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 							hyphenators.get(hyphenatorQuery),
 							new Function<Hyphenator,LiblouisTranslator>() {
 								public LiblouisTranslator apply(Hyphenator hyphenator) {
-									try { return new LiblouisTranslatorImpl(table, hyphenator); }
+									try { return new LiblouisTranslatorImpl(table, hyphenator);
+									}
 									catch (CompilationException e) {
-										logger.warn("Could not create translator for table: " + Arrays.toString(table), e); }
-									return null; }}),
-						Predicates.notNull())); }
+										logger.warn("Could not create translator for table: " + Arrays.toString(table), e);
+									}
+									return null;
+							}
+						}),
+						Predicates.notNull()));
+			}
 			try {
 				translators = Iterables.<LiblouisTranslator>concat(
 					translators,
-					Optional.<LiblouisTranslator>fromNullable(new LiblouisTranslatorImpl(table)).asSet()); }
+					Optional.<LiblouisTranslator>fromNullable(new LiblouisTranslatorImpl(table)).asSet());
+			}
 			catch (CompilationException e) {
-				logger.warn("Could not create translator for table: " + Arrays.toString(table), e); }
-			return translators; }
+				logger.warn("Could not create translator for table: " + Arrays.toString(table), e);
+			}
+			return translators;
+		}
 		logger.debug("Could not resolve table: " + Arrays.toString(table));
 		return empty;
 	}
@@ -244,8 +262,12 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 							tableProvider.get(locale),
 							new Function<URI[],Iterable<LiblouisTranslator>>() {
 								public Iterable<LiblouisTranslator> apply(URI[] table) {
-									return LiblouisJnaImpl.this.get(table, hyphenator, locale); }}));
-				return empty; }};
+									return LiblouisJnaImpl.this.get(table, hyphenator, locale);
+								}
+							}));
+				return empty;
+			}
+		};
 	
 	public Iterable<LiblouisTranslator> get(String query) {
 		return provider.get(query);
@@ -308,7 +330,8 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 				if (val != null)
 					if ("auto".equals(val))
 						hyphenate[i] = true;
-				typeform[i] |= typeformFromInlineCSS(style);}
+				typeform[i] |= typeformFromInlineCSS(style);
+			}
 			return transform(text, typeform, hyphenate);
 		}
 		
@@ -346,7 +369,8 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 			boolean someNotHyphenate = false;
 			for (int i = 0; i < hyphenate.length; i++) {
 				if (hyphenate[i]) someHyphenate = true;
-				else someNotHyphenate = true; }
+				else someNotHyphenate = true;
+			}
 			if (someHyphenate) {
 				byte[] autoHyphens = doHyphenate(_text);
 				if (someNotHyphenate) {
@@ -360,9 +384,13 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 							for (int k = 0; k < unhyphenated[j].length() - 1; k++)
 								autoHyphens[i++] = 0;
 							if (i < autoHyphens.length)
-								autoHyphens[i++] = 0; }}}
+								autoHyphens[i++] = 0;
+						}
+					}
+				}
 				for (int i = 0; i < autoHyphens.length; i++)
-					positions[i] += autoHyphens[i]; }
+					positions[i] += autoHyphens[i];
+			}
 			byte[] _typeform = null;
 			for (byte b : typeform)
 				if (b != Typeform.PLAIN) {
@@ -373,8 +401,11 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 						_typeform[j] = typeform[i];
 						if (positions != null && j < positions.length && (positions[j] & 4) == 4) {
 							i++;
-							while (unhyphenated[i].length() == 0) i++; }}
-					break; }
+							while (unhyphenated[i].length() == 0) i++;
+						}
+					}
+					break;
+			}
 			try {
 				
 				// Translate
@@ -395,7 +426,8 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 					for (String s : SEGMENT_SPLITTER.split(braille)) {
 						rv[i++] = s;
 						while (i < text.length && unhyphenated[i].length() == 0)
-							rv[i++] = ""; }
+							rv[i++] = "";
+					}
 					if (i == text.length)
 						return rv;
 					else {
@@ -414,9 +446,11 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 						for (int j = 0; j < positions.length; j++) {
 							if ((positions[j] & 4) == 4) {
 								i++;
-								while (i < text.length && unhyphenated[i].length() == 0) i++; }
+								while (i < text.length && unhyphenated[i].length() == 0) i++;
+							}
 							int n = (i % 31) + 1;
-							positions[j] |= (byte)(n << 3); }
+							positions[j] |= (byte)(n << 3);
+						}
 						r = translator.translate(_text, positions, _typeform);
 						braille = r.getBraille();
 						outputPositions = r.getHyphenPositions();
@@ -432,7 +466,9 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 									rv[i++] = b.toString();
 									b = new StringBuffer();
 									while (((n - i - 1) % 31) > 0)
-										rv[i++] = ""; }}
+										rv[i++] = "";
+							}
+						}
 						b.append(braille.charAt(braille.length() - 1));
 						rv[i++] = b.toString();
 						while (i < text.length && unhyphenated[i].length() == 0)
@@ -440,9 +476,13 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 						if (i == text.length)
 							return rv;
 						else
-							throw new RuntimeException("Coding error"); }}}
+							throw new RuntimeException("Coding error");
+					}
+				}
+			}
 			catch (TranslationException e) {
-				throw new RuntimeException(e); }
+				throw new RuntimeException(e);
+			}
 		}
 		
 		protected byte[] doHyphenate(String text) {
@@ -453,9 +493,11 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 		
 		public String display(String braille) {
 			try {
-				return translator.display(braille); }
+				return translator.display(braille);
+			}
 			catch (TranslationException e) {
-				throw new RuntimeException(e); }
+				throw new RuntimeException(e);
+			}
 		}
 	}
 	
@@ -498,17 +540,22 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 				for (String s : SEGMENT_SPLITTER.split(_text)) {
 					while (unhyphenated[i].length() == 0)
 						rv[i++] = "";
-					rv[i++] = s; }
-				while(i < text.length)
+					rv[i++] = s;
+				}
+				while (i < text.length)
 					rv[i++] = "";
-				return rv; }
+				return rv;
+			}
 		}
 		
 		@Override
 		protected byte[] doHyphenate(String text) {
-			try { return translator.hyphenate(text); }
+			try {
+				return translator.hyphenate(text);
+			}
 			catch (TranslationException e) {
-				throw new RuntimeException(e); }
+				throw new RuntimeException(e);
+			}
 		}
 	}
 	
@@ -540,7 +587,8 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 			else if (prop.equals("text-decoration") && value.equals("underline"))
 				typeform |= Typeform.UNDERLINE;
 			else
-				logger.warn("Inline CSS property {} not supported", prop); }
+				logger.warn("Inline CSS property {} not supported", prop);
+		}
 		return typeform;
 	}
 	
@@ -569,7 +617,8 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 			else if (tt.equals("louis-comp"))
 				typeform |= Typeform.COMPUTER;
 			else
-				logger.warn("text-transform: {} not supported", tt); }
+				logger.warn("text-transform: {} not supported", tt);
+		}
 		return typeform;
 	}
 	

--- a/pipeline-braille-utils/liblouis/liblouis-core/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisJnaImpl.java
+++ b/pipeline-braille-utils/liblouis/liblouis-core/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisJnaImpl.java
@@ -299,6 +299,8 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 			for (int i = 0; i < cssStyle.length; i++) {
 				Map<String,String> style = CSS_PARSER.split(cssStyle[i]);
 				typeform[i] = typeformFromInlineCSS(style);
+				if (style.containsKey("text-transform"))
+					typeform[i] |= typeformFromTextTransform(style.get("text-transform"));
 				hyphenate[i] = false;
 				if (style.containsKey("hyphens") && "auto".equals(style.get("hyphens")))
 					hyphenate[i] = true; }
@@ -509,7 +511,7 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 		= Splitter.on(';').omitEmptyStrings().withKeyValueSeparator(Splitter.on(':').limit(2).trimResults());
 	
 	/**
-	 * @parameter cssStyle An inline CSS style
+	 * @parameter style An inline CSS style
 	 * @returns the corresponding typeform. Possible values are:
 	 * - 0 = PLAIN
 	 * - 1 = ITALIC (font-style: italic|oblique)
@@ -527,13 +529,42 @@ public class LiblouisJnaImpl implements LiblouisTranslator.Provider {
 		for (String prop : style.keySet()) {
 			String value = style.get(prop);
 			if (prop.equals("font-style") && (value.equals("italic") || value.equals("oblique")))
-				typeform += Typeform.ITALIC;
+				typeform |= Typeform.ITALIC;
 			else if (prop.equals("font-weight") && value.equals("bold"))
-				typeform += Typeform.BOLD;
+				typeform |= Typeform.BOLD;
 			else if (prop.equals("text-decoration") && value.equals("underline"))
-				typeform += Typeform.UNDERLINE;
+				typeform |= Typeform.UNDERLINE;
 			else
 				logger.warn("Inline CSS property {} not supported", prop); }
+		return typeform;
+	}
+	
+	private final static Splitter TEXT_TRANSFORM_PARSER = Splitter.on(' ').omitEmptyStrings().trimResults();
+	
+	/**
+	 * @parameter textTransform A text-transform value as a space separated list of keywords.
+	 * @returns the corresponding typeform. Possible values are:
+	 * - 0 = PLAIN
+	 * - 1 = ITALIC (louis-ital)
+	 * - 2 = BOLD (louis-bold)
+	 * - 4 = UNDERLINE (louis-under)
+	 * - 8 = COMPUTER (louis-comp)
+	 * These values can be added for multiple emphasis.
+	 * @see http://liblouis.googlecode.com/svn/documentation/liblouis.html#lou_translateString
+	 */
+	protected static byte typeformFromTextTransform(String textTransform) {
+		byte typeform = Typeform.PLAIN;
+		for (String tt : TEXT_TRANSFORM_PARSER.split(textTransform)) {
+			if (tt.equals("louis-ital"))
+				typeform |= Typeform.ITALIC;
+			else if (tt.equals("louis-bold"))
+				typeform |= Typeform.BOLD;
+			else if (tt.equals("louis-under"))
+				typeform |= Typeform.UNDERLINE;
+			else if (tt.equals("louis-comp"))
+				typeform |= Typeform.COMPUTER;
+			else
+				logger.warn("text-transform: {} not supported", tt); }
 		return typeform;
 	}
 	

--- a/pipeline-braille-utils/liblouis/liblouis-core/src/test/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisJnaImplTest.java
+++ b/pipeline-braille-utils/liblouis/liblouis-core/src/test/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisJnaImplTest.java
@@ -13,4 +13,10 @@ public class LiblouisJnaImplTest {
 		             LiblouisJnaImpl.typeformFromInlineCSS(
 			             " text-decoration: underline ;font-weight: bold  ; hyphens:auto; color: #FF00FF "));
 	}
+	
+	@Test
+	public void testTypeformFromTextTransform() {
+		assertEquals(Typeform.BOLD + Typeform.UNDERLINE,
+		             LiblouisJnaImpl.typeformFromTextTransform(" louis-bold  ital louis-under foo "));
+	}
 }

--- a/pipeline-braille-utils/liblouis/liblouis-core/src/test/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisJnaImplTest.java
+++ b/pipeline-braille-utils/liblouis/liblouis-core/src/test/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisJnaImplTest.java
@@ -13,6 +13,22 @@ public class LiblouisJnaImplTest {
 		             LiblouisJnaImpl.typeformFromInlineCSS(
 			             " text-decoration: underline ;font-weight: bold  ; hyphens:auto; color: #FF00FF "));
 	}
+
+	@Test
+	public void testTextFromTextTransform() {
+		assertEquals("IK BEN MOOS",
+			LiblouisJnaImpl.textFromTextTransform("Ik ben Moos",
+				" uppercase "));
+		assertEquals("ik ben moos",
+			LiblouisJnaImpl.textFromTextTransform("Ik ben Moos",
+				" lowercase "));
+		assertEquals("ik ben moos",
+			LiblouisJnaImpl.textFromTextTransform("Ik ben Moos",
+				" uppercase lowercase "));
+		assertEquals("Ik ben Moos",
+			LiblouisJnaImpl.textFromTextTransform("Ik ben Moos",
+				" foo bar "));
+	}
 	
 	@Test
 	public void testTypeformFromTextTransform() {


### PR DESCRIPTION
- [x] Delete typeform-indication property in favour of text-transform (a9610d133a8fc479386512e13a69ed013e0c2b5d)
- [x] Support text-transform in css-utils
- [x] Support text-transform property in `CSSStyledTextTransform`/`CSSBlockTransform` implementations
- [x] Support text-transform property in @counter-style rules (ed4f2353463b8dd500478a45be54cc546fb71d95)
- [ ] Support text-transform property in Dotify's `BrailleTranslator`s (note that API needs to change for this)

Depends on:
- [ ] https://github.com/snaekobbi/braille-css-spec/issues/12
