### PR TITLE
Lines are broken in the middle of words when Dotify translator is used

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -62,7 +62,7 @@
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
                 <artifactId>dotify-formatter</artifactId>
-                <version>1.1.1</version>
+                <version>1.1.2-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>

--- a/pipeline-braille-utils/dotify-utils/dotify-formatter/src/main/java/org/daisy/pipeline/braille/dotify/impl/BypassTranslatorFactoryService.java
+++ b/pipeline-braille-utils/dotify-utils/dotify-formatter/src/main/java/org/daisy/pipeline/braille/dotify/impl/BypassTranslatorFactoryService.java
@@ -297,6 +297,7 @@ public class BypassTranslatorFactoryService implements BrailleTranslatorFactoryS
 							swoBuffer.set(bufSize - 1, (byte)(swoBuffer.get(bufSize - 1) | SOFT_WRAP_WITHOUT_HYPHEN));
 						break;
 					case SPACE:
+					case BRAILLE_PATTERN_BLANK:
 						if (bufSize > 0)
 							swoBuffer.set(bufSize - 1, (byte)(swoBuffer.get(bufSize - 1) | SOFT_WRAP_WITHOUT_HYPHEN));
 						charBuffer.append(BRAILLE_PATTERN_BLANK);
@@ -304,7 +305,6 @@ public class BypassTranslatorFactoryService implements BrailleTranslatorFactoryS
 						swoBuffer.add(SOFT_WRAP_AFTER_SPACE);
 						break;
 					case NBSP:
-					case BRAILLE_PATTERN_BLANK:
 						charBuffer.append(BRAILLE_PATTERN_BLANK);
 						bufSize ++;
 						swoBuffer.add((byte)0x0);

--- a/pipeline-braille-utils/dotify-utils/dotify-formatter/src/test/xprocspec/test_obfl-to-pef.xprocspec
+++ b/pipeline-braille-utils/dotify-utils/dotify-formatter/src/test/xprocspec/test_obfl-to-pef.xprocspec
@@ -511,60 +511,6 @@
         </pef>
       </x:document>
     </x:expect>
-  </x:scenario><x:scenario label="test_07" focus="true">
-    <x:call step="pxi:test">
-      <x:input port="source">
-        <x:document type="inline">
-          <obfl xmlns="http://www.daisy.org/ns/2011/obfl" version="2011-1" xml:lang="und">
-          <layout-master name="a" page-width="20" page-height="10" duplex="false">
-            <default-template>
-              <header/>
-              <footer/>
-            </default-template>
-          </layout-master>
-          <sequence master="a">
-            <block vertical-align="before" vertical-position="5">
-              ⠤⠤⠤<br/>
-              ⠤⠤⠤
-            </block>
-          </sequence>
-        </obfl>
-        </x:document>
-      </x:input>
-    </x:call>
-    <x:context label="result">
-      <x:document type="port" port="result"/>
-    </x:context>
-    <x:expect label="valid" type="validate" grammar="relax-ng">
-      <x:document type="file" href="http://www.daisy.org/pipeline/modules/braille/pef-utils/schema/pef-2008-1.rng"/>
-    </x:expect>
-    <x:expect label="valid" type="validate" grammar="schematron">
-      <x:document type="file" href="http://www.daisy.org/pipeline/modules/braille/pef-utils/schema/pef-2008-1.sch"/>
-    </x:expect>
-    <x:expect label="result" type="custom" href="http://www.daisy.org/pipeline/modules/braille/pef-utils/library.xpl" step="x:pef-compare">
-      <x:document type="inline">
-        <pef xmlns="http://www.daisy.org/ns/2008/pef" version="2008-1">
-          <head xmlns:dc="http://purl.org/dc/elements/1.1/">
-            <meta>
-              <dc:format>application/x-pef+xml</dc:format>
-            </meta>
-          </head>
-          <body>
-            <volume cols="20" rows="10" rowgap="0" duplex="false">
-              <section>
-                <page>
-                  <row/>
-                  <row/>
-                  <row/>
-                  <row>⠤⠤⠤</row>
-                  <row>⠤⠤⠤</row>
-                </page>
-              </section>
-            </volume>
-          </body>
-        </pef>
-      </x:document>
-    </x:expect>
   </x:scenario>
   
 </x:description>

--- a/pipeline-braille-utils/dotify-utils/dotify-formatter/src/test/xprocspec/test_obfl-to-pef.xprocspec
+++ b/pipeline-braille-utils/dotify-utils/dotify-formatter/src/test/xprocspec/test_obfl-to-pef.xprocspec
@@ -513,4 +513,61 @@
     </x:expect>
   </x:scenario>
   
+  <!--
+      line breaking
+  -->
+  <x:scenario label="test_09">
+    <x:call step="pxi:test">
+      <x:input port="source">
+        <x:document type="inline">
+          <obfl xmlns="http://www.daisy.org/ns/2011/obfl" version="2011-1" xml:lang="und">
+          <layout-master name="a" page-width="20" page-height="10" duplex="false">
+            <default-template>
+              <header/>
+              <footer/>
+            </default-template>
+          </layout-master>
+          <sequence master="a">
+            <block>
+              ⠤⠤⠤⠀⠤⠤⠤⠤⠀⠤⠤⠤⠤⠤⠀⠤⠤⠤⠤⠤⠤⠀⠤⠤⠤⠤⠤⠤⠤⠀⠤⠤⠤⠤⠤⠤⠤⠤⠀⠤⠤⠤⠤⠤⠤⠤⠤⠤⠀⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤
+            </block>
+          </sequence>
+        </obfl>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="valid" type="validate" grammar="relax-ng">
+      <x:document type="file" href="http://www.daisy.org/pipeline/modules/braille/pef-utils/schema/pef-2008-1.rng"/>
+    </x:expect>
+    <x:expect label="valid" type="validate" grammar="schematron">
+      <x:document type="file" href="http://www.daisy.org/pipeline/modules/braille/pef-utils/schema/pef-2008-1.sch"/>
+    </x:expect>
+    <x:expect label="result" type="custom" href="http://www.daisy.org/pipeline/modules/braille/pef-utils/library.xpl" step="x:pef-compare">
+      <x:document type="inline">
+        <pef xmlns="http://www.daisy.org/ns/2008/pef" version="2008-1">
+          <head xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <meta>
+              <dc:format>application/x-pef+xml</dc:format>
+            </meta>
+          </head>
+          <body>
+            <volume cols="20" rows="10" rowgap="0" duplex="false">
+              <section>
+                <page>
+                  <row>⠤⠤⠤⠀⠤⠤⠤⠤⠀⠤⠤⠤⠤⠤</row>
+                  <row>⠤⠤⠤⠤⠤⠤⠀⠤⠤⠤⠤⠤⠤⠤</row>
+                  <row>⠤⠤⠤⠤⠤⠤⠤⠤⠀⠤⠤⠤⠤⠤⠤⠤⠤⠤</row>
+                  <row>⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤</row>
+                </page>
+              </section>
+            </volume>
+          </body>
+        </pef>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+  
 </x:description>

--- a/pom.xml
+++ b/pom.xml
@@ -25,14 +25,14 @@
   </scm>
 
   <modules>
-    <!-- <module>bom</module> -->
-    <!-- <module>parent</module> -->
+    <module>bom</module>
+    <module>parent</module>
     <!-- <module>pipeline-braille-utils/common-utils</module> -->
     <!-- <module>pipeline-braille-utils/css-utils</module> -->
     <!-- <module>pipeline-braille-utils/pef-utils</module> -->
     <!-- <module>pipeline-braille-utils/obfl-utils</module> -->
     <!-- <module>pipeline-braille-utils/liblouis-utils</module> -->
-    <!-- <module>pipeline-braille-utils/dotify-utils</module> -->
+    <module>pipeline-braille-utils/dotify-utils</module>
     <!-- <module>pipeline-braille-utils/libhyphen-utils</module> -->
     <!-- <module>pipeline-braille-utils/texhyph-utils</module> -->
     <!-- <module>pipeline-braille-scripts/zedai-to-pef</module> -->


### PR DESCRIPTION
as if the text is one long word.