### PR TITLE
Deep inheritance, ++

### DIFF
--- a/maven/build-helper/pom.xml
+++ b/maven/build-helper/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.daisy.pipeline.modules.braille</groupId>
   <artifactId>build-helper</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>DAISY Pipeline 2 :: Braille Modules Build Helper</name>

--- a/maven/build-helper/src/main/resources/org/daisy/pipeline/braille/build/process-catalog.xsl
+++ b/maven/build-helper/src/main/resources/org/daisy/pipeline/braille/build/process-catalog.xsl
@@ -55,7 +55,7 @@
     <xsl:template match="cat:uri[@px:extends]" mode="ds">
         <xsl:next-match/>
         <xsl:result-document href="{$outputDir}/generated-scripts/{replace(@uri,'^.*/([^/]+)$','$1')}" method="xml">
-            <xsl:variable name="original-script" select="document(@px:extends)"/>
+            <xsl:variable name="original-script" select="document((//cat:uri[current()/@px:extends=@name]/@uri, @px:extends)[1])"/>
             <xsl:if test="not($original-script)">
                 <xsl:message terminate="yes" select="concat('Unable to resolve script extension: ', @px:extends)"/>
             </xsl:if>

--- a/maven/build-helper/src/main/resources/org/daisy/pipeline/braille/build/process-catalog.xsl
+++ b/maven/build-helper/src/main/resources/org/daisy/pipeline/braille/build/process-catalog.xsl
@@ -97,7 +97,7 @@
         <xsl:variable name="new-attributes" as="xs:string*" select="@*/concat('{',namespace-uri(.),'}',name(.))"/>
         <xsl:copy>
             <xsl:apply-templates select="@*" mode="#current"/>
-            <xsl:sequence select="$original-input-or-option/@*[not(concat('{',namespace-uri(.),'}',name(.))=$new-attributes)]"/>
+            <xsl:sequence select="$original-input-or-option/@*[not(concat('{',namespace-uri(.),'}',name(.))=$new-attributes or name()='select' and current()/@required = 'true')]"/>
             <xsl:if test="not(p:documentation)">
                 <xsl:sequence select="$original-input-or-option/p:documentation"/>
             </xsl:if>

--- a/maven/parent/pom.xml
+++ b/maven/parent/pom.xml
@@ -214,7 +214,7 @@
         <plugin>
           <groupId>org.daisy.pipeline.modules.braille</groupId>
           <artifactId>build-helper</artifactId>
-          <version>1.0.1-SNAPSHOT</version>
+          <version>1.1.0-SNAPSHOT</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Allow scripts to inherit from scripts that inherit from scripts

If you have scripts A and B in the same module, and script C in either the same module or another module, then A needs to extend the *generated* version of B so that documentation and attributes are carried through from C.

## Added support for `px:inherit="prepend|append"` on elements with `px:role="name|desc"`.

For instance:

```xml
<p:option name="stuff" ...>
    <p:documentation xmlns="...">
        <p px:role="name">Stuff</p>
        <p px:role="desc" px:inherit="prepend">This and that</p>
    </p:documentation>
</p:option>
```

In the above example, the content of the `<p px:role="desc">` for the option `stuff` in the script that this script extends, will be prepended to the description in this script. So the generated content might be:

```xml
<p:option name="stuff" ...>
    <p:documentation xmlns="...">
        <p px:role="name">Stuff</p>
        <p px:role="desc">Short description

More description

This and that</p>
    </p:documentation>
</p:option>
```

Two newlines are inserted between the documentation in the script and the documentation in the script that is extended.

## Allow referencing uris from same catalog in px:extends

The issue is that when loading documents referenced by px:extends using the XSLT `document` function; URIs from within the same catalog.xml does not seem to work. Using this patch, it works. However, corner cases using rewriteURI etc won't work, so it would be better to fix this in ProcessCatalogMojo.java. I'm just not quite sure how.

## Other

- if an optional option becomes required; don't copy its select attribute
