### PR TITLE
Fix circular dependency between fileset-utils and mediatype-utils

### DIFF
--- a/pipeline-braille-scripts/dtbook-to-pef/pom.xml
+++ b/pipeline-braille-scripts/dtbook-to-pef/pom.xml
@@ -55,14 +55,6 @@
       <scope>runtime</scope>
     </dependency>
     <!--
-        for p:unzip-fileset in fileset-utils
-    -->
-    <dependency>
-      <groupId>org.daisy.pipeline.modules</groupId>
-      <artifactId>mediatype-utils</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <!--
         test dependencies
     -->
     <dependency>

--- a/pipeline-braille-scripts/dtbook-to-pef/src/test/java/XProcSpecTest.java
+++ b/pipeline-braille-scripts/dtbook-to-pef/src/test/java/XProcSpecTest.java
@@ -61,8 +61,6 @@ public class XProcSpecTest {
 				pipelineModule("fileset-utils"),
 				pipelineModule("metadata-utils"),
 				pipelineModule("dtbook-utils"),
-				// for p:unzip-fileset in fileset-utils
-				pipelineModule("mediatype-utils"),
 				// logging
 				logbackClassic(),
 				// xprocspec

--- a/pipeline-braille-scripts/xml-to-pef/pom.xml
+++ b/pipeline-braille-scripts/xml-to-pef/pom.xml
@@ -46,14 +46,6 @@
       <scope>runtime</scope>
     </dependency>
     <!--
-        for p:unzip-fileset in fileset-utils
-    -->
-    <dependency>
-      <groupId>org.daisy.pipeline.modules</groupId>
-      <artifactId>mediatype-utils</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <!--
         test dependencies
     -->
     <dependency>

--- a/pipeline-braille-scripts/xml-to-pef/src/test/java/XProcSpecTest.java
+++ b/pipeline-braille-scripts/xml-to-pef/src/test/java/XProcSpecTest.java
@@ -50,8 +50,6 @@ public class XProcSpecTest {
 				pipelineModule("common-utils"),
 				pipelineModule("file-utils"),
 				pipelineModule("fileset-utils"),
-				// for p:unzip-fileset in fileset-utils
-				pipelineModule("mediatype-utils"),
 				// logging
 				logbackClassic(),
 				// xprocspec

--- a/pipeline-braille-utils/liblouis-utils/liblouis-formatter/pom.xml
+++ b/pipeline-braille-utils/liblouis-utils/liblouis-formatter/pom.xml
@@ -72,14 +72,6 @@
       <scope>runtime</scope>
     </dependency>
     <!--
-        for p:unzip-fileset in fileset-utils
-    -->
-    <dependency>
-      <groupId>org.daisy.pipeline.modules</groupId>
-      <artifactId>mediatype-utils</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <!--
         test dependencies
     -->
     <dependency>

--- a/pipeline-braille-utils/liblouis-utils/liblouis-formatter/src/test/java/LiblouisFormatterTest.java
+++ b/pipeline-braille-utils/liblouis-utils/liblouis-formatter/src/test/java/LiblouisFormatterTest.java
@@ -59,8 +59,6 @@ public class LiblouisFormatterTest {
 				pipelineModule("file-utils"),
 				pipelineModule("fileset-utils"),
 				brailleModule("liblouis-tables"),
-				// for p:unzip-fileset in fileset-utils
-				pipelineModule("mediatype-utils"),
 				// logging
 				logbackClassic(),
 				// xprocspec

--- a/pipeline-braille-utils/liblouis-utils/liblouis-mathml/pom.xml
+++ b/pipeline-braille-utils/liblouis-utils/liblouis-mathml/pom.xml
@@ -53,14 +53,6 @@
       <scope>runtime</scope>
     </dependency>
     <!--
-        for p:unzip-fileset in fileset-utils
-    -->
-    <dependency>
-      <groupId>org.daisy.pipeline.modules</groupId>
-      <artifactId>mediatype-utils</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <!--
         test dependencies
     -->
     <dependency>

--- a/pipeline-braille-utils/liblouis-utils/liblouis-mathml/src/test/java/LiblouisMathMLTest.java
+++ b/pipeline-braille-utils/liblouis-utils/liblouis-mathml/src/test/java/LiblouisMathMLTest.java
@@ -53,8 +53,6 @@ public class LiblouisMathMLTest {
 				brailleModule("liblouis-native").forThisPlatform(),
 				pipelineModule("file-utils"),
 				pipelineModule("fileset-utils"),
-				// for p:unzip-fileset in fileset-utils
-				pipelineModule("mediatype-utils"),
 				// logging
 				logbackClassic(),
 				// xprocspec


### PR DESCRIPTION
Depends on:
- [x] https://github.com/daisy/pipeline-modules-common/pull/95
- [x] https://github.com/daisy/pipeline-mod-braille/pull/141